### PR TITLE
Audit response

### DIFF
--- a/contract/.openzeppelin/unknown-421614.json
+++ b/contract/.openzeppelin/unknown-421614.json
@@ -50,6 +50,16 @@
       "address": "0x3aeAb3a0754245de2235f3D1547778003d013f7c",
       "txHash": "0xd2300c164d6d46dd85e378850dd9a6a7a0dcf38d725b6887db41d5b29f06c672",
       "kind": "transparent"
+    },
+    {
+      "address": "0x52EA368D8a722713a0acaA7b538Db8f5aEB75cE9",
+      "txHash": "0x63e6d4e4d024d9ed8dab20ca898d0a1a9d1aa46c3bddd0b44a7b280f08c04641",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9AC17beEf8e0507A31C58841B8ff4a9503cF65eC",
+      "txHash": "0x2491dd7dc9083d2741d8dea93f9c2722ff311c3f546339ce3b320ad61f4fd37b",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -1205,6 +1215,792 @@
               "slot": "0"
             }
           ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7b911c43c3a1e4fb799c002a32662d49b3674a17a6988a90995f3ee5fbdb8c31": {
+      "address": "0x2c0497F4DE87E8af3544F7dF008CFa92b5590013",
+      "txHash": "0x19d9832445f042c0bcd556fc57c6f8bd37d8c740e9c80d29bc80ed199d4cb82d",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "marketplaceData",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(MarketplaceDataV1)3148",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:54"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:56"
+          },
+          {
+            "label": "jobs",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_struct(JobPost)3218_storage)dyn_storage",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:58"
+          },
+          {
+            "label": "whitelistWorkers",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:61"
+          },
+          {
+            "label": "unicrowAddress",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:63"
+          },
+          {
+            "label": "unicrowDisputeAddress",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_address",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:64"
+          },
+          {
+            "label": "unicrowArbitratorAddress",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_address",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:65"
+          },
+          {
+            "label": "treasuryAddress",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_address",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:67"
+          },
+          {
+            "label": "unicrowMarketplaceFee",
+            "offset": 20,
+            "slot": "7",
+            "type": "t_uint16",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_array(t_uint256)41_storage",
+            "contract": "MarketplaceV1",
+            "src": "contracts/MarketplaceV1.sol:70"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)64_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)14_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)136_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_string_storage)dyn_storage": {
+            "label": "string[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(JobPost)3218_storage)dyn_storage": {
+            "label": "struct JobPost[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)41_storage": {
+            "label": "uint256[41]",
+            "numberOfBytes": "1312"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(MarketplaceDataV1)3148": {
+            "label": "contract MarketplaceDataV1",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(JobPost)3218_storage": {
+            "label": "struct JobPost",
+            "members": [
+              {
+                "label": "state",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "whitelistWorkers",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "roles",
+                "type": "t_struct(JobRoles)3181_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "title",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "tags",
+                "type": "t_array(t_string_storage)dyn_storage",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "contentHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "multipleApplicants",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "timestamp",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "9"
+              },
+              {
+                "label": "maxTime",
+                "type": "t_uint32",
+                "offset": 24,
+                "slot": "9"
+              },
+              {
+                "label": "deliveryMethod",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "collateralOwed",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              },
+              {
+                "label": "escrowId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "12"
+              },
+              {
+                "label": "resultHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "13"
+              },
+              {
+                "label": "rating",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "14"
+              },
+              {
+                "label": "disputed",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "14"
+              }
+            ],
+            "numberOfBytes": "480"
+          },
+          "t_struct(JobRoles)3181_storage": {
+            "label": "struct JobRoles",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "arbitrator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "worker",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "a4d262e9217ac626837fd4aff5e8fda87d9a609022381051d453ac6f5bdef564": {
+      "address": "0x9b051cebFAf80166CDB065243e4455d253663046",
+      "txHash": "0x23c4dd53bad30cd47d2eda4d948f28ab4cee1f990075e50dd191f764a3cc3451",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "marketplace",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(MarketplaceV1)5982",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:108"
+          },
+          {
+            "label": "jobEvents",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_array(t_struct(JobEventData)1690_storage)dyn_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:111"
+          },
+          {
+            "label": "users",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_struct(User)1742_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:115"
+          },
+          {
+            "label": "userAddresses",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:116"
+          },
+          {
+            "label": "arbitrators",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(JobArbitrator)1727_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:118"
+          },
+          {
+            "label": "arbitratorAddresses",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:119"
+          },
+          {
+            "label": "userRatings",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_struct(UserRating)1749_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:122"
+          },
+          {
+            "label": "userReviews",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_array(t_struct(Review)1760_storage)dyn_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:124"
+          },
+          {
+            "label": "meceTags",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_string_memory_ptr,t_string_storage)",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:126"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)41_storage",
+            "contract": "MarketplaceDataV1",
+            "src": "contracts/MarketplaceDataV1.sol:128"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)64_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)14_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(JobEventData)1690_storage)dyn_storage": {
+            "label": "struct JobEventData[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Review)1760_storage)dyn_storage": {
+            "label": "struct Review[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)41_storage": {
+            "label": "uint256[41]",
+            "numberOfBytes": "1312"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(MarketplaceV1)5982": {
+            "label": "contract MarketplaceV1",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_struct(Review)1760_storage)dyn_storage)": {
+            "label": "mapping(address => struct Review[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(JobArbitrator)1727_storage)": {
+            "label": "mapping(address => struct JobArbitrator)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(User)1742_storage)": {
+            "label": "mapping(address => struct User)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(UserRating)1749_storage)": {
+            "label": "mapping(address => struct UserRating)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_string_storage)": {
+            "label": "mapping(string => string)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_struct(JobEventData)1690_storage)dyn_storage)": {
+            "label": "mapping(uint256 => struct JobEventData[])",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(JobArbitrator)1727_storage": {
+            "label": "struct JobArbitrator",
+            "members": [
+              {
+                "label": "address_",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "publicKey",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "bio",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "avatar",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "fee",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "settledCount",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "5"
+              },
+              {
+                "label": "refusedCount",
+                "type": "t_uint16",
+                "offset": 4,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(JobEventData)1690_storage": {
+            "label": "struct JobEventData",
+            "members": [
+              {
+                "label": "type_",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "address_",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "data_",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "timestamp_",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(Review)1760_storage": {
+            "label": "struct Review",
+            "members": [
+              {
+                "label": "reviewer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "jobId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "rating",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "text",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "timestamp",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(User)1742_storage": {
+            "label": "struct User",
+            "members": [
+              {
+                "label": "address_",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "publicKey",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "bio",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "avatar",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "reputationUp",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "reputationDown",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(UserRating)1749_storage": {
+            "label": "struct UserRating",
+            "members": [
+              {
+                "label": "averageRating",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "numberOfReviews",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
           "erc7201:openzeppelin.storage.Ownable": [
             {
               "contract": "OwnableUpgradeable",

--- a/contract/contracts/MarketplaceDataV1.sol
+++ b/contract/contracts/MarketplaceDataV1.sol
@@ -71,6 +71,9 @@ struct Review {
     uint32 timestamp;
 }
 
+uint8 constant RATING_MIN = 1;
+uint8 constant RATING_MAX = 5;
+
 contract MarketplaceDataV1 is OwnableUpgradeable {
     event JobEvent(uint256 indexed jobId, JobEventData eventData);
     event PublicKeyRegistered(address indexed addr, bytes pubkey);
@@ -425,6 +428,12 @@ contract MarketplaceDataV1 is OwnableUpgradeable {
         address userAddress_,
         uint8 reviewRating_
     ) public onlyMarketplace {
+        // check reviewRating_ value bounds to avoid possible integer overflow in averageRating calculation
+        require(
+            reviewRating_ >= RATING_MIN && reviewRating_ <= RATING_MAX,
+            "Invalid review score"
+        );
+
         UserRating storage rating = userRatings[userAddress_];
 
         rating.averageRating = uint16(
@@ -477,6 +486,11 @@ contract MarketplaceDataV1 is OwnableUpgradeable {
         uint8 rating_,
         string memory text_
     ) public onlyMarketplace {
+        require(
+            rating_ >= RATING_MIN && rating_ <= RATING_MAX,
+            "Invalid review score"
+        );
+
         userReviews[target_].push(
             Review({
                 reviewer: reviewer_,

--- a/contract/contracts/unicrow/README.md
+++ b/contract/contracts/unicrow/README.md
@@ -1,3 +1,5 @@
-same as https://github.com/unicrowio/contracts @ 21b0c855b6feb2dba8953462b88f63d9932a5775
+this directory contains the code external to marketplace. it was audited elsewhere. we include this code as a production deployment prerequisite and also to run the test suite.
+
+same as https://github.com/unicrowio/contracts @ bcd5d785663944603d433dbfd38b91c6f5f52c2c
 
 with imports changed to 4.9.4 openzeppelin contracts

--- a/contract/scripts/000-deploy-marketplace.ts
+++ b/contract/scripts/000-deploy-marketplace.ts
@@ -23,7 +23,6 @@ async function main() {
   );
 
   const marketplace = (await upgrades.deployProxy(Marketplace, [
-    await deployer.getAddress(),
     await unicrow.getAddress(),
     await unicrowDispute.getAddress(),
     await unicrowArbitrator.getAddress(),

--- a/contract/scripts/001-deploy-marketplace-public.ts
+++ b/contract/scripts/001-deploy-marketplace-public.ts
@@ -29,7 +29,6 @@ async function main() {
   );
 
   const marketplace = (await upgrades.deployProxy(Marketplace, [
-    await deployer.getAddress(),
     unicrowAddress,
     unicrowDisputeAddress,
     unicrowArbitratorAddress,

--- a/contract/scripts/config.json
+++ b/contract/scripts/config.json
@@ -1,12 +1,12 @@
 {
-  "ownerAddress": "0x98427EB0A7AC42229901922F533E63210B5dD53f",
+  "ownerAddress": "0x11AD04D7C7d5c7912dab1555f677F3579A469064",
   "marketplaceFeeAddress": "0x000000000000000000000000000000000000beef",
-  "marketplaceAddress": "0xA235730429fEa9A638b5b614133093175c49cd14",
-  "marketplaceDataAddress": "0x3aeAb3a0754245de2235f3D1547778003d013f7c",
-  "fakeTokenAddress": "0x53743D547c87d81d6A066A41B421E9b7588DEeB9",
-  "unicrowAddress": "0x6d98b03C09EaD582a77C093bdb2d3E85683Aa956",
-  "unicrowDisputeAddress": "0x3dC5d22716599e7FcD1bbB1752544D9dfa7e719E",
-  "unicrowArbitratorAddress": "0xdB400Dd10a4A645c2C1429b3A48F1449E7e4F64A",
-  "unicrowClaimAddress": "0x7761D841D83c5Aeb876DB2b110798C668cd83872",
+  "marketplaceAddress": "0x60a1561455c9Bd8fe6B0F05976d7F84ff2eff5a3",
+  "marketplaceDataAddress": "0xB43014F1328dd3732f60C06107F1b5a03eea60AF",
+  "fakeTokenAddress": "0x1235747639a5da96d3B52EffC0E179957C94Dc71",
+  "unicrowAddress": "0xc1Ec57Ba2a0B27d3C17a73dC4f160fA3Ad83d07A",
+  "unicrowDisputeAddress": "0xeC5b67E980E2F472e21AB18C4c685bB7F5B522C5",
+  "unicrowArbitratorAddress": "0x643e37Ab434406F47B1369CbbbcDa13eC301Fa21",
+  "unicrowClaimAddress": "0x42f98E65E54a85411DA99cF1cC6Bd79c575e0Cc1",
   "multicall3Address": "0xca11bde05977b3631167028862be2a173976ca11"
 }

--- a/contract/scripts/config.json
+++ b/contract/scripts/config.json
@@ -1,12 +1,12 @@
 {
-  "ownerAddress": "0x11AD04D7C7d5c7912dab1555f677F3579A469064",
+  "ownerAddress": "0x98427EB0A7AC42229901922F533E63210B5dD53f",
   "marketplaceFeeAddress": "0x000000000000000000000000000000000000beef",
-  "marketplaceAddress": "0x60a1561455c9Bd8fe6B0F05976d7F84ff2eff5a3",
-  "marketplaceDataAddress": "0xB43014F1328dd3732f60C06107F1b5a03eea60AF",
-  "fakeTokenAddress": "0x1235747639a5da96d3B52EffC0E179957C94Dc71",
-  "unicrowAddress": "0xc1Ec57Ba2a0B27d3C17a73dC4f160fA3Ad83d07A",
-  "unicrowDisputeAddress": "0xeC5b67E980E2F472e21AB18C4c685bB7F5B522C5",
-  "unicrowArbitratorAddress": "0x643e37Ab434406F47B1369CbbbcDa13eC301Fa21",
-  "unicrowClaimAddress": "0x42f98E65E54a85411DA99cF1cC6Bd79c575e0Cc1",
+  "marketplaceAddress": "0x52EA368D8a722713a0acaA7b538Db8f5aEB75cE9",
+  "marketplaceDataAddress": "0x9AC17beEf8e0507A31C58841B8ff4a9503cF65eC",
+  "fakeTokenAddress": "0x53743D547c87d81d6A066A41B421E9b7588DEeB9",
+  "unicrowAddress": "0x6d98b03C09EaD582a77C093bdb2d3E85683Aa956",
+  "unicrowDisputeAddress": "0x3dC5d22716599e7FcD1bbB1752544D9dfa7e719E",
+  "unicrowArbitratorAddress": "0xdB400Dd10a4A645c2C1429b3A48F1449E7e4F64A",
+  "unicrowClaimAddress": "0x7761D841D83c5Aeb876DB2b110798C668cd83872",
   "multicall3Address": "0xca11bde05977b3631167028862be2a173976ca11"
 }

--- a/contract/tasks/index.ts
+++ b/contract/tasks/index.ts
@@ -234,7 +234,7 @@ task("marketplace:seed", "Seed local marketplace instance")
     const workerMessage = "I can do it!";
     const { hash: workerMessageHash } = await publishToIpfs(workerMessage, workerSessionKey);
 
-    await marketplace.connect(worker).postThreadMessage(jobId, workerMessageHash);
+    await marketplace.connect(worker).postThreadMessage(jobId, workerMessageHash, owner.address);
 
     await marketplace.connect(owner).payStartJob(jobId, worker.address);
   }
@@ -263,13 +263,13 @@ task("marketplace:seed", "Seed local marketplace instance")
     const workerMessage = "I can do it!";
     const { hash: workerMessageHash } = await publishToIpfs(workerMessage, workerSessionKey);
 
-    await marketplace.connect(worker).postThreadMessage(jobId, workerMessageHash);
+    await marketplace.connect(worker).postThreadMessage(jobId, workerMessageHash, owner.address);
 
     const ownerSessionKey = await getSessionKey(owner, await marketplaceData.connect(owner).publicKeys(worker.address), jobId);
     const ownerMessage = "Go ahead!";
     const { hash: ownerMessageHash } = await publishToIpfs(ownerMessage, ownerSessionKey);
 
-    await marketplace.connect(owner).postThreadMessage(jobId, ownerMessageHash);
+    await marketplace.connect(owner).postThreadMessage(jobId, ownerMessageHash, owner.address);
 
     // worker takes the job
     const revision = await marketplaceData.eventsLength(jobId);

--- a/contract/test/communication.test.ts
+++ b/contract/test/communication.test.ts
@@ -18,7 +18,6 @@ describe("Encrypted communication tests", async () => {
       "MarketplaceV1"
     );
     marketplace = (await upgrades.deployProxy(Marketplace, [
-      await deployer.getAddress(),
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -249,7 +248,6 @@ describe("Encrypted communication tests", async () => {
       "MarketplaceV1"
     );
     marketplace = (await upgrades.deployProxy(Marketplace, [
-      await deployer.getAddress(),
       ethers.ZeroAddress,
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/contract/test/marketplace.test.ts
+++ b/contract/test/marketplace.test.ts
@@ -153,7 +153,6 @@ describe("Marketplace Unit Tests", () => {
     );
 
     const marketplace = (await upgrades.deployProxy(Marketplace, [
-      await deployer.getAddress(),
       await unicrow.getAddress(),
       await unicrowDispute.getAddress(),
       await unicrowArbitrator.getAddress(),
@@ -264,44 +263,6 @@ describe("Marketplace Unit Tests", () => {
       ).to.be.reverted;
     });
 
-    it("transfer pauser", async () => {
-      const { marketplace, deployer, user1 } = await loadFixture(deployContractsFixture);
-      await expect(marketplace
-        .connect(deployer)
-        .transferPauser(await user1.getAddress())
-      ).to.emit(marketplace, 'PauserTransferred')
-      .withArgs(await deployer.getAddress(), await user1.getAddress());
-
-      expect(await marketplace.pauser()).to.equal(await user1.getAddress());
-    });
-
-    it("non owner cannot transfer pauser", async () => {
-      const { marketplace, marketplaceData, user1 } = await loadFixture(deployContractsFixture);
-      await expect(marketplace
-        .connect(user1)
-        .transferPauser(await user1.getAddress())
-      ).to.be.reverted;
-    });
-
-    it("transfer treasury", async () => {
-      const { marketplace, deployer, user1 } = await loadFixture(deployContractsFixture);
-      await expect(marketplace
-        .connect(deployer)
-        .transferTreasury(await user1.getAddress())
-      ).to.emit(marketplace, 'TreasuryTransferred')
-      .withArgs(await deployer.getAddress(), await user1.getAddress());
-
-      expect(await marketplace.treasury()).to.equal(await user1.getAddress());
-    });
-
-    it("non owner cannot transfer treasury", async () => {
-      const { marketplace, marketplaceData, user1 } = await loadFixture(deployContractsFixture);
-      await expect(marketplace
-        .connect(user1)
-        .transferTreasury(await user1.getAddress())
-      ).to.be.reverted;
-    });
-
     it("pause/unpause", async () => {
       const { marketplace, deployer, user1 } = await loadFixture(deployContractsFixture);
       await expect(marketplace
@@ -361,7 +322,7 @@ describe("Marketplace Unit Tests", () => {
     it("can not call initializer", async () => {
       const { marketplace } = await loadFixture(deployContractsFixture);
       await expect(
-        marketplace.initialize(ZeroAddress, ZeroAddress, ZeroAddress, ZeroAddress, ZeroAddress, 0)
+        marketplace.initialize(ZeroAddress, ZeroAddress, ZeroAddress, ZeroAddress, 0)
       ).to.be.revertedWithCustomError({interface: Initializable__factory.createInterface()}, "InvalidInitialization");
     });
   });
@@ -631,14 +592,14 @@ describe("Marketplace Unit Tests", () => {
       const { marketplace, deployer } = await loadFixture(deployContractsFixture);
       await expect(marketplace
         .connect(deployer)
-        .setUnicrowMarketplaceAddress(ethers.ZeroAddress)
+        .setTreasuryAddress(ethers.ZeroAddress)
       ).to.be.not.reverted;
-      expect(await marketplace.unicrowMarketplaceAddress()).to.equal(ethers.ZeroAddress);
+      expect(await marketplace.treasuryAddress()).to.equal(ethers.ZeroAddress);
 
       const randomWallet = ethers.Wallet.createRandom();
       await expect(marketplace
         .connect(randomWallet.connect(deployer.provider))
-        .setUnicrowMarketplaceAddress(ethers.ZeroAddress)
+        .setTreasuryAddress(ethers.ZeroAddress)
       ).to.be.revertedWithCustomError({interface: OwnableUpgradeable__factory.createInterface()}, "OwnableUnauthorizedAccount");
     });
 
@@ -2486,7 +2447,7 @@ describe("Marketplace Unit Tests", () => {
       expect(await fakeToken.balanceOf(await user2.getAddress())).to.equal(BigInt(1079e18));
       expect(await fakeToken.balanceOf(await marketplace.getAddress())).to.equal(0);
       expect(await fakeToken.balanceOf(await unicrowGlobal.getAddress())).to.equal(0);
-      expect(await fakeToken.balanceOf(await marketplace.unicrowMarketplaceAddress())).to.equal(BigInt(19.31e18));
+      expect(await fakeToken.balanceOf(await marketplace.treasuryAddress())).to.equal(BigInt(19.31e18));
       expect(await fakeToken.balanceOf(unicrowProtocolFeeAddress)).to.equal(BigInt(0.69e18));
 
       expect((await marketplace.connect(user1).jobs(jobId)).state).to.be.equal(JobState.Closed);
@@ -2888,7 +2849,7 @@ describe("Marketplace Unit Tests", () => {
       expect(await fakeToken.balanceOf(await arbitrator.getAddress())).to.equal(BigInt(1e18));
       expect(await fakeToken.balanceOf(await marketplace.getAddress())).to.equal(BigInt(79.2e18));
       expect(await fakeToken.balanceOf(await unicrowGlobal.getAddress())).to.equal(0);
-      expect(await fakeToken.balanceOf(await marketplace.unicrowMarketplaceAddress())).to.equal(BigInt(3.86e18));
+      expect(await fakeToken.balanceOf(await marketplace.treasuryAddress())).to.equal(BigInt(3.86e18));
       expect(await fakeToken.balanceOf(unicrowProtocolFeeAddress)).to.equal(BigInt(0.13e18));
 
       const job = await marketplace.jobs(jobId);
@@ -2967,7 +2928,7 @@ describe("Marketplace Unit Tests", () => {
       expect(await fakeToken.balanceOf(await marketplace.getAddress())).to.equal(BigInt(0e18));
       expect((await marketplace.connect(user1).jobs(jobId)).collateralOwed).to.be.equal(BigInt(0e18));
       expect(await fakeToken.balanceOf(await unicrowGlobal.getAddress())).to.equal(0);
-      expect(await fakeToken.balanceOf(await marketplace.unicrowMarketplaceAddress())).to.equal(BigInt(19.31e18));
+      expect(await fakeToken.balanceOf(await marketplace.treasuryAddress())).to.equal(BigInt(19.31e18));
       expect(await fakeToken.balanceOf(unicrowProtocolFeeAddress)).to.equal(BigInt(0.69e18));
 
       const job = await marketplace.jobs(jobId);
@@ -3046,7 +3007,7 @@ describe("Marketplace Unit Tests", () => {
       expect(await fakeToken.balanceOf(await marketplace.getAddress())).to.equal(BigInt(99e18));
       expect((await marketplace.connect(user1).jobs(jobId)).collateralOwed).to.be.equal(BigInt(99e18));
       expect(await fakeToken.balanceOf(await unicrowGlobal.getAddress())).to.equal(0);
-      expect(await fakeToken.balanceOf(await marketplace.unicrowMarketplaceAddress())).to.equal(BigInt(0e18));
+      expect(await fakeToken.balanceOf(await marketplace.treasuryAddress())).to.equal(BigInt(0e18));
       expect(await fakeToken.balanceOf(unicrowProtocolFeeAddress)).to.equal(BigInt(0e18));
 
       const job = await marketplace.jobs(jobId);


### PR DESCRIPTION
High 1: Added an explainer comment that tokens must be chosen carefully, user's responsibility
High 2: Fixed as suggested
Medium 1: Removed mention of ETH from documentation, suggest using WETH ERC20
Medium 2: Added an explainer comment that arbitrators must be chosen and evaluated carefully, user's responsibility
Medium 3: Fixed as suggested
Low 1: Fixed as suggested
Low 2: removed meceShortForm unused variable, removed treasury and pauser members and getters/setters, preserve ability to pause/unpause but set it to onlyOwner access check, rename unicrowMarketplaceAddress to treasuryAddress for clarity
Low 3: Move rating checks to MarketPlaceData and make use of them
Low 4: Added a hint in Unicrow's readme, that this is an external library audited elsewhere