### PR TITLE
Unicrow requires sender address in the pay() function

### DIFF
--- a/contract/contracts/MarketplaceV1.sol
+++ b/contract/contracts/MarketplaceV1.sol
@@ -734,6 +734,7 @@ contract MarketplaceV1 is OwnableUpgradeable, PausableUpgradeable {
             );
 
             job.escrowId = unicrow.pay(
+                address(this),
                 escrowInput,
                 job.roles.arbitrator,
                 marketplaceData.getArbitratorFee(job.roles.arbitrator)
@@ -796,6 +797,7 @@ contract MarketplaceV1 is OwnableUpgradeable, PausableUpgradeable {
         );
 
         job.escrowId = unicrow.pay(
+            address(this),
             escrowInput,
             job.roles.arbitrator,
             marketplaceData.getArbitratorFee(job.roles.arbitrator)

--- a/contract/contracts/unicrow/Unicrow.sol
+++ b/contract/contracts/unicrow/Unicrow.sol
@@ -111,6 +111,7 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
 
     /// @inheritdoc IUnicrow
     function pay(
+        address sender,
         EscrowInput calldata input,
         address arbitrator,
         uint16 arbitratorFee
@@ -118,8 +119,7 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
         // Get current escrow id from the incremental counter
         uint256 escrowId = escrowIdCounter.current();
 
-        // If the buyer was set to zero address in the input, set buyer to msg.sender
-        address buyer = input.buyer == address(0) ? msg.sender : input.buyer;
+        address buyer = input.buyer;
 
         // Amount of the payment in ERC20 tokens
         uint amount = input.amount;
@@ -127,8 +127,8 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
         // Make sure there's something left for the seller :-)
         require(arbitratorFee + input.marketplaceFee + protocolFee < 10000, "1-026");
 
-        // Payment can't use address(0)
-        require(escrows[escrowId].buyer == address(0), "0-001");
+        // Buyer cannot be empty
+        require(buyer != address(0), "0-001");
 
         // Seller cannot be empty
         require(input.seller != address(0), "0-002");
@@ -154,7 +154,7 @@ contract Unicrow is ReentrancyGuard, IUnicrow, Context {
             // If the payment was made in ERC20 and not ETH, execute the transfer
             SafeERC20.safeTransferFrom(
                 IERC20(input.currency),
-                msg.sender,
+                sender,
                 address(this),
                 amount
             );

--- a/contract/contracts/unicrow/interfaces/IUnicrow.sol
+++ b/contract/contracts/unicrow/interfaces/IUnicrow.sol
@@ -11,11 +11,13 @@ interface IUnicrow {
    * @notice If the balance claiming transaction fails due to the token's contract error or malicious behavior, 
    * @notice   it is not possible to try to claim the balance again.
    * @dev Escrow ID is generated automatically by the contract
+   * @param sender An address from which the amount  will be deposited (it may be different to a buyer if e.g. another smart contract is paying on behalf of an end user)
    * @param input Escrow input (seller, marketplace, currency, and challenge period information)
    * @param arbitrator Arbitrator address (submit zero address to not set an arbitrator)
    * @param arbitratorFee Arbitrator Fee
    */
   function pay(
+    address sender,
     EscrowInput memory input,
     address arbitrator,
     uint16 arbitratorFee


### PR DESCRIPTION
Based on some feedback Unicrow removed msg.sender from pay() function. This is to reflect that change in Marketplace contract. Please quick review and merge if all OK 