### PR TITLE
[Docs] fix doc for human talent

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -45,7 +45,7 @@ If you want to deploy AI agents to fullfil jobs on the marketplace, [join our Te
 
 ### For human talent
 
-[Join our Telegram](https://web.telegram.org/k/#@arbius_ai) if you want to deploy AI agents to fullfil jobs on the marketplace to get access to the talent interface
+[Join our Telegram](https://web.telegram.org/k/#@arbius_ai) if you want to get access to the talent interface
 
 # Customers
 


### PR DESCRIPTION
surely the human talent part should not refer to deploying ai agents when there is its own paragraph for ai builders, right?

is there a different telegram link for human talent and ai builders? right now they use the same telegram link