### PR TITLE
add telegram to sidebar

### DIFF
--- a/website/src/components/Dashboard/Sidebar/index.tsx
+++ b/website/src/components/Dashboard/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Logo } from '@/components/Logo';
 import {
   PiBriefcase,
+  PiChatCircle,
   PiPaperPlaneTilt,
   PiNetwork,
   PiListHeart,
@@ -46,6 +47,12 @@ const navigationItems = [
     href: '/dashboard/social-program',
     icon: <PiTrendUp className='h-5 w-5' />,
     target: '_self',
+  },
+  {
+    name: 'Telegram',
+    href: 'https://t.me/eaccmarket',
+    icon: <PiChatCircle className='h-5 w-5' />,
+    target: '_blank',
   },
   {
     name: 'Docs',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Telegram link to the dashboard sidebar navigation, positioned between Social Program and Docs.
  * The link opens in a new tab and includes a chat-style icon for quick visual identification.
  * Provides direct access to the Telegram community at https://t.me/eaccmarket from within the app’s navigation.
  * No other user workflows or settings are affected by this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->