### PR TITLE
Update link to Arbiscan for transaction hashes

### DIFF
--- a/website/src/app/social-program/WeeklyDistribution.tsx
+++ b/website/src/app/social-program/WeeklyDistribution.tsx
@@ -117,7 +117,7 @@ export const WeeklyDistribution = ({
                           {formatAddress(contributor.address)}
                         </code>
                         <a
-                          href={`https://etherscan.io/tx/${contributor.txHash}`}
+                          href={`https://arbiscan.io/tx/${contributor.txHash}`}
                           target='_blank'
                           rel='noopener noreferrer'
                           className='text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction links in the Top Contributors section to open on Arbiscan instead of Etherscan, ensuring users see the right transaction details for the Arbitrum network.
  * Links continue to open in a new tab with the same look and behavior, avoiding confusion or dead links for Arbitrum transactions.
  * No other UI elements or interactions in the Weekly Distribution page were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->