### PR TITLE
Raising a dispute fixes workflow

### DIFF
--- a/website/src/app/dashboard/jobs/[id]/JobActions/DisputeButton.tsx
+++ b/website/src/app/dashboard/jobs/[id]/JobActions/DisputeButton.tsx
@@ -105,8 +105,32 @@ export function DisputeButton({
   const characterCount = message.length;
   const minCharacters = 50;
 
+    // DISPUTE ACTIONS
+  let timeLeft = 0;
+  let timeLeftAfterDeadline = 0;
+  if (job && job.jobTimes && job.jobTimes.assignedAt) {
+    // Calculate deadline: assignedAt + maxTime
+    const deadline = job.jobTimes.assignedAt + job.maxTime;
+    // Calculate time remaining: deadline - current time
+    const currentTime = Math.floor(Date.now() / 1000);
+    timeLeft = deadline - currentTime;
+    timeLeftAfterDeadline = deadline + 86400 - currentTime; // 24 hours after deadline
+  }
+
   return (
     <>
+      {/* Overdue warning if job is overdue but still within 24h dispute window */}
+      {job.roles.creator === address && timeLeft < 0 && timeLeftAfterDeadline > 0 && (
+        <div className="mb-3 rounded-xl border border-amber-300 bg-amber-50 p-4 text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200 flex items-center gap-3">
+          <PiWarning className="h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          <div>
+            <div className="font-semibold">Job is overdue</div>
+            <div className="text-xs">
+              After the job is overdue, you have <span className="font-bold">24 hours</span> left to raise a dispute if needed.
+            </div>
+          </div>
+        </div>
+      )}
       {/* Fixed trigger button - removed horizontal padding, reduced vertical padding */}
       <button
         disabled={isDisputing || isConfirming}

--- a/website/src/app/dashboard/jobs/[id]/JobButtonActions.tsx
+++ b/website/src/app/dashboard/jobs/[id]/JobButtonActions.tsx
@@ -194,8 +194,21 @@ const JobButtonActions = ({
     job.state !== JobState.Closed && address === job.roles.arbitrator;
 
   // DISPUTE ACTIONS
+  let timeLeft = 0;
+  let timeLeftAfterDeadline = 0;
+  if (job && job.jobTimes && job.jobTimes.assignedAt) {
+    // Calculate deadline: assignedAt + maxTime
+    const deadline = job.jobTimes.assignedAt + job.maxTime;
+    // Calculate time remaining: deadline - current time
+    const currentTime = Math.floor(Date.now() / 1000);
+    timeLeft = deadline - currentTime;
+    timeLeftAfterDeadline = deadline + 86400 - currentTime; // 24 hours after deadline
+  }
+
 
   const showDisputeButton =
+    (job.roles.creator === address && timeLeftAfterDeadline > 0) ||
+    job.roles.worker === address &&
     job.state === JobState.Taken &&
     job.roles.arbitrator !== zeroAddress &&
     address !== job.roles.arbitrator &&

--- a/website/src/app/dashboard/jobs/[id]/JobSidebar.tsx
+++ b/website/src/app/dashboard/jobs/[id]/JobSidebar.tsx
@@ -346,7 +346,7 @@ export default function JobSidebar({
         {/* Delivery Status Section */}
         {job?.state === JobState.Taken &&
           job.resultHash === zeroHash &&
-          address === job.roles.creator &&
+          (address === job.roles.creator || address === job.roles.worker) &&
           events.length > 0 && (
             <InfoSection
               title='Delivery Status'
@@ -371,7 +371,7 @@ export default function JobSidebar({
                     </span>
                   }
                 />
-                <ProgressBar value={5} label='Progress' />
+                <ProgressBar value={timeLeft > 0 ? 5 : 10-0} label='Progress' />
               </div>
             </InfoSection>
           )}


### PR DESCRIPTION
- Make delivery status appear for worker too
- fix progress should be 100% if overdue
- make raise a dispute appear only if you're a worker or a creator but inside before overdue o after 24 hours
- show a warning if job is overdue and its within the overdue time to raise a dispute.
- if job is overdue hidde raise a dispute button for job creators