### PR TITLE
Remove reputation up when result is delivered from subsquid

### DIFF
--- a/subsquid/src/main.ts
+++ b/subsquid/src/main.ts
@@ -609,13 +609,6 @@ processor.run(db, async (ctx) => {
 
                 job.resultHash = event.data_;
 
-                const userId = job.roles.worker;
-                const user: User =
-                  userCache[userId] ??
-                  (await ctx.store.findOneByOrFail(User, { id: userId }))!;
-                user.reputationUp++;
-                userCache[userId] = user;
-
                 await handleNotification(job.roles.creator, jobEvent, ctx);
 
                 break;

--- a/website/src/app/jobs/[id]/JobChat/ReviewsList.tsx
+++ b/website/src/app/jobs/[id]/JobChat/ReviewsList.tsx
@@ -15,52 +15,18 @@ export function ReviewsList({
   selectedUser?: User;
 }) {
   // const { data: user } = useUser(address as string);
-  const { data: reviews } = useReviews(address as string);
+  const {
+    data: reviews,
+    totalReviews = 0,
+    positiveReviews = 0,
+    negativeReviews = 0,
+    positiveReviewPercentage = 0,
+  } = useReviews(address as string);
+  
   const { data: users } = useUsersByAddresses(
     reviews?.map((review) => review.reviewer) ?? []
   );
   
-  const {
-    totalReviews,
-    positiveReviews,
-    negativeReviews,
-    positiveReviewPercentage,
-    actualAverageRating,
-  } = useMemo(() => {
-    if (!reviews || reviews.length === 0) {
-      return {
-        totalReviews: 0,
-        positiveReviews: 0,
-        negativeReviews: 0,
-        positiveReviewPercentage: 0,
-        actualAverageRating: 0,
-      };
-    }
-
-    type Stats = { total: number; positive: number; negative: number; sum: number };
-
-    const acc = reviews.reduce(
-      (acc: Stats, review) => {
-        acc.total++;
-        acc.sum += review.rating;
-        if (review.rating >= 3) acc.positive++;
-        else acc.negative++;
-        return acc;
-      },
-      { total: 0, positive: 0, negative: 0, sum: 0 }
-    );
-
-    const avg = acc.total > 0 ? acc.sum / acc.total : 0;
-    const percentage = acc.total > 0 ? Math.round((acc.positive / acc.total) * 100) : 0;
-
-    return {
-      totalReviews: acc.total,
-      positiveReviews: acc.positive,
-      negativeReviews: acc.negative,
-      positiveReviewPercentage: percentage,
-      actualAverageRating: avg,
-    };
-  }, [reviews]);
   return (
     <div>
       <div className='flex items-center'>

--- a/website/src/app/jobs/[id]/JobChat/ReviewsList.tsx
+++ b/website/src/app/jobs/[id]/JobChat/ReviewsList.tsx
@@ -2,6 +2,7 @@ import useReviews from '@/hooks/subsquid/useReviews';
 import useUsersByAddresses from '@/hooks/subsquid/useUsersByAddresses';
 import type { User } from '@effectiveacceleration/contracts/dist/src/interfaces';
 import moment from 'moment';
+import { useMemo } from 'react';
 import { IoChevronBack } from 'react-icons/io5';
 
 export function ReviewsList({
@@ -18,13 +19,48 @@ export function ReviewsList({
   const { data: users } = useUsersByAddresses(
     reviews?.map((review) => review.reviewer) ?? []
   );
-  const totalReviews =
-    (selectedUser?.reputationUp ?? 0) + (selectedUser?.reputationDown ?? 0);
-  const positiveReviewPercentage =
-    totalReviews === 0
-      ? 0
-      : Math.round(((selectedUser?.reputationUp ?? 0) / totalReviews) * 100);
+  
+  const {
+    totalReviews,
+    positiveReviews,
+    negativeReviews,
+    positiveReviewPercentage,
+    actualAverageRating,
+  } = useMemo(() => {
+    if (!reviews || reviews.length === 0) {
+      return {
+        totalReviews: 0,
+        positiveReviews: 0,
+        negativeReviews: 0,
+        positiveReviewPercentage: 0,
+        actualAverageRating: 0,
+      };
+    }
 
+    type Stats = { total: number; positive: number; negative: number; sum: number };
+
+    const acc = reviews.reduce(
+      (acc: Stats, review) => {
+        acc.total++;
+        acc.sum += review.rating;
+        if (review.rating >= 3) acc.positive++;
+        else acc.negative++;
+        return acc;
+      },
+      { total: 0, positive: 0, negative: 0, sum: 0 }
+    );
+
+    const avg = acc.total > 0 ? acc.sum / acc.total : 0;
+    const percentage = acc.total > 0 ? Math.round((acc.positive / acc.total) * 100) : 0;
+
+    return {
+      totalReviews: acc.total,
+      positiveReviews: acc.positive,
+      negativeReviews: acc.negative,
+      positiveReviewPercentage: percentage,
+      actualAverageRating: avg,
+    };
+  }, [reviews]);
   return (
     <div>
       <div className='flex items-center'>
@@ -56,7 +92,7 @@ export function ReviewsList({
               </div>
               <div className='flex flex-1 flex-col items-center'>
                 <span className='text-2xl font-semibold text-primary'>
-                  {selectedUser?.reputationUp ?? 0}
+                  {positiveReviews}
                 </span>
                 <span className='text-center text-xs leading-3'>
                   Positive reviews
@@ -64,7 +100,7 @@ export function ReviewsList({
               </div>
               <div className='flex flex-1 flex-col items-center'>
                 <span className='text-2xl font-semibold text-primary'>
-                  {selectedUser?.reputationDown ?? 0}
+                  {negativeReviews}
                 </span>
                 <span className='text-center text-xs leading-3'>
                   Negative reviews

--- a/website/src/app/users/[address]/UserPageClient.tsx
+++ b/website/src/app/users/[address]/UserPageClient.tsx
@@ -137,7 +137,7 @@ export default function UserPageClient({ address }: UserPageClientProps) {
       // You might want to show a toast notification here
     }
   };
-  console.log('reviews', reviews);
+
   return (
     <Layout borderless>
       <div className='flex h-full min-h-full flex-col'>

--- a/website/src/app/users/[address]/UserPageClient.tsx
+++ b/website/src/app/users/[address]/UserPageClient.tsx
@@ -59,48 +59,21 @@ export default function UserPageClient({ address }: UserPageClientProps) {
     loading: userLoading,
     error: userError,
   } = useUser(address);
-  const { data: reviews, loading: reviewsLoading } = useReviews(address);
+  const {
+    data: reviews,
+    loading: reviewsLoading,
+    totalReviews = 0,
+    positiveReviews = 0,
+    negativeReviews = 0,
+    positiveReviewPercentage = 0,
+    actualAverageRating = 0,
+  } = useReviews(address);
   const { data: users } = useUsersByAddresses(
     reviews?.map((review) => review.reviewer) ?? []
   );
   const [copiedAddress, setCopiedAddress] = useState(false);
 
-  const { totalReviews, positiveReviews, negativeReviews, positiveReviewPercentage, actualAverageRating } = useMemo(() => {
-    if (!reviews || reviews.length === 0) {
-      return {
-        totalReviews: 0,
-        positiveReviews: 0,
-        negativeReviews: 0,
-        positiveReviewPercentage: 0,
-        actualAverageRating: user?.averageRating ?? 0,
-      };
-    }
 
-    type Stats = { total: number; positive: number; negative: number; sum: number };
-
-    // acc is the accumulator (running totals) — clearer than "s"
-    const acc = reviews.reduce(
-      (acc: Stats, review) => {
-        acc.total++;
-        acc.sum += review.rating;
-        if (review.rating >= 3) acc.positive++;
-        else acc.negative++;
-        return acc; // return the updated accumulator for the next iteration
-      },
-      { total: 0, positive: 0, negative: 0, sum: 0 }
-    );
-
-    const avg = acc.total > 0 ? acc.sum / acc.total : 0;
-    const percentage = acc.total > 0 ? Math.round((acc.positive / acc.total) * 100) : 0;
-
-    return {
-      totalReviews: acc.total,
-      positiveReviews: acc.positive,
-      negativeReviews: acc.negative,
-      positiveReviewPercentage: percentage,
-      actualAverageRating: avg,
-    };
-  }, [reviews, user?.averageRating]);
 
   // Format address for display (0x1234...5678)
   const formatAddress = (addr: string) => {

--- a/website/src/components/Dashboard/Sidebar/UserInfo.tsx
+++ b/website/src/components/Dashboard/Sidebar/UserInfo.tsx
@@ -5,6 +5,7 @@ import { useAccount } from 'wagmi';
 import useUser from '@/hooks/subsquid/useUser';
 import useArbitrator from '@/hooks/subsquid/useArbitrator';
 import ProfileImage from '@/components/ProfileImage';
+import useReviews from '@/hooks/subsquid/useReviews';
 
 export const UserInfo = () => {
   const { address } = useAccount();
@@ -15,6 +16,11 @@ export const UserInfo = () => {
   const userInfo = user || arbitrator;
   const displayName = userInfo?.name || 'Anonymous';
   const displayRole = arbitrator ? 'Arbitrator' : user ? 'Member' : 'Guest';
+  const {
+    totalReviews = 0,
+    actualAverageRating = 0,
+  } = useReviews(address as string);
+
   const initials =
     displayName
       .split(' ')
@@ -24,16 +30,7 @@ export const UserInfo = () => {
       .slice(0, 2) || 'AN';
 
   // TODO: Get actual values from user data
-  const jobCount = user?.reputationUp || 0; // Using reputation as placeholder
-  const rating =
-    userInfo && (user?.reputationUp || 0) > 0
-      ? ((user?.reputationUp || 0) /
-          ((user?.reputationUp || 0) + (user?.reputationDown || 0))) *
-        5
-      : 0;
-
   if (!address || !userInfo) return null;
-
   return (
     <div className='mx-3 mb-4 mt-auto p-4'>
       <Link href={`/users/${address}`}>
@@ -79,14 +76,14 @@ export const UserInfo = () => {
                 <p className='text-xs text-gray-400 transition-colors duration-300 group-hover:text-gray-300'>
                   Jobs
                 </p>
-                <p className='text-sm font-bold text-white'>{jobCount}</p>
+                <p className='text-sm font-bold text-white'>{totalReviews}</p>
               </div>
               <div className='flex-1 text-center'>
                 <p className='text-xs text-gray-400 transition-colors duration-300 group-hover:text-gray-300'>
                   Rating
                 </p>
                 <p className='text-sm font-bold text-white'>
-                  {rating.toFixed(1)}
+                  {actualAverageRating}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
When worker delivers result, their reputation goes up because of main.ts:

```
    const userId = job.roles.worker;
    const user: User =
      userCache[userId] ??
      (await ctx.store.findOneByOrFail(User, { id: userId }))!;
    user.reputationUp++;
    userCache[userId] = user;
```

Reputation should only go up after  `function approveResult(` is called on MarketplaceV1.sol and `marketplaceData.userDelivered(job.roles.worker);` is called.

woker should not receive reputation for delivering a result that is not approved by the job owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stopped automatic reputation increases when a job is marked Delivered; delivery events no longer adjust user reputation.

- **New Features**
  - Reviews hook now returns aggregated stats (total, positive/negative counts, positive percentage, average rating).
  - Reviews list, user profile, and sidebar now display these review-based metrics and handle empty review sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->